### PR TITLE
Feat/gcc2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.36.0
+      uses: anothrNick/github-tag-action@1.39.0
       env:
         RELEASE_BRANCHES: master
         DEFAULT_BUMP: patch

--- a/main.tf
+++ b/main.tf
@@ -26,14 +26,14 @@ data "aws_iam_policy_document" "trusted_accounts" {
     }
     # Only allow role to be assumed if MFA token is present
     condition {
-      test      = "StringEquals"
-      variable  = "aws:userid"
-      values    = [format("%s:%s",var.identities[count.index].principal,var.identities[count.index].email)]
+      test     = "StringEquals"
+      variable = "aws:userid"
+      values   = [format("%s:%s", var.agency_assume_local_role_id, var.identities[count.index].email)]
     }
     condition {
-      test      = "StringEquals"
-      variable  = "sts:ExternalId"
-      values    = [var.identities[count.index].email]
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [var.identities[count.index].email]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,18 @@
 #
 # iam-role
 # --------
-# this module assists in creating an iam role that enables members of groups listed
-# in the `var.group_names` variable to assume it
-#
+# this module assists in creating an iam role that enables Techpass SSO to assume this role
+# techpass users should be created as CLOUD_ASSUME_ROLE
 
 # ref: https://www.terraform.io/docs/providers/aws/d/caller_identity.html
 data "aws_caller_identity" "current" {}
 
 # ref: https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html
-data "aws_iam_policy_document" "trusted_account" {
+data "aws_iam_policy_document" "trusted_accounts" {
+  count = length(var.identities)
+
   statement {
-    sid = "TrustedAccounts"
+    sid = "User${count.index}"
     actions = [
     "sts:AssumeRole"]
     principals {
@@ -25,60 +26,20 @@ data "aws_iam_policy_document" "trusted_account" {
     }
     # Only allow role to be assumed if MFA token is present
     condition {
-      test     = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values = [
-        "true",
-      ]
+      test      = "StringEquals"
+      variable  = "aws:userid"
+      values    = [format("%s:%s",var.identities[count.index].principal,var.identities[count.index].email)]
     }
-  }
-}
-
-# ref: https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html
-data "aws_iam_policy_document" "trusted_roles" {
-  count = length(var.trusted_root_accounts) == 0 ? 0 : 1
-  statement {
-    sid = "TrustedRoles"
-    actions = [
-      "sts:AssumeRole"
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = var.trusted_root_accounts
-    }
-    # Only allow role to be assumed if MFA token is present
     condition {
-      test     = "StringEquals"
-      variable = "sts:ExternalId"
-      values = [
-        var.external_id
-      ]
-    }
-
-    condition {
-      test     = "StringLike"
-      variable = "aws:PrincipalArn"
-      values   = var.trusted_role_arns
+      test      = "StringEquals"
+      variable  = "sts:ExternalId"
+      values    = [var.identities[count.index].email]
     }
   }
 }
 
 data "aws_iam_policy_document" "iam_trusted" {
-  source_policy_documents = compact([
-    data.aws_iam_policy_document.trusted_account.json,
-    length(data.aws_iam_policy_document.trusted_roles) > 0 ? data.aws_iam_policy_document.trusted_roles[0].json : ""
-  ])
-}
-
-# ref: https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html
-data "aws_iam_policy_document" "iam_rolling" {
-  statement {
-    actions = [
-      "sts:AssumeRole",
-    ]
-    resources = formatlist("arn:aws:iam::${data.aws_caller_identity.current.account_id}:group/%s", var.group_names)
-    effect    = "Allow"
-  }
+  source_policy_documents = data.aws_iam_policy_document.trusted_accounts[*].json
 }
 
 # ref: https://www.terraform.io/docs/providers/aws/r/iam_role.html
@@ -86,23 +47,9 @@ resource "aws_iam_role" "iam_role" {
   name                  = var.name
   path                  = var.path
   description           = var.description
-  permissions_boundary  = var.enable_gcci_boundary ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/GCCIAccountBoundary" : ""
   assume_role_policy    = data.aws_iam_policy_document.iam_trusted.json
   max_session_duration  = var.max_session_duration
   force_detach_policies = true
-}
-
-# ref: https://www.terraform.io/docs/providers/aws/r/iam_policy.html
-resource "aws_iam_policy" "iam_allowing_group_to_assume_role" {
-  name        = "${var.name}-group-enabler"
-  description = "allows for groups [${join(",", var.group_names)}] to assume role/${var.name}"
-  policy      = data.aws_iam_policy_document.iam_rolling.json
-}
-
-# ref: https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html
-resource "aws_iam_role_policy_attachment" "iam_grouping" {
-  role       = aws_iam_role.iam_role.name
-  policy_arn = aws_iam_policy.iam_allowing_group_to_assume_role.arn
 }
 
 # Maps the given list of existing policies to the role

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,40 +23,40 @@ output "name" {
   value       = aws_iam_role.iam_role.name
 }
 
-output "policy" {
-  description = "policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.policy
-}
+# output "policy" {
+#   description = "policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.policy
+# }
 
-output "policy_arn" {
-  description = "arn of policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.arn
-}
+# output "policy_arn" {
+#   description = "arn of policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.arn
+# }
 
-output "policy_description" {
-  description = "description of policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.description
-}
+# output "policy_description" {
+#   description = "description of policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.description
+# }
 
-output "policy_id" {
-  description = "id of policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.id
-}
+# output "policy_id" {
+#   description = "id of policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.id
+# }
 
-output "policy_name" {
-  description = "name of policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.name
-}
+# output "policy_name" {
+#   description = "name of policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.name
+# }
 
-output "policy_path" {
-  description = "path of policy attached to this role"
-  value       = aws_iam_policy.iam_allowing_group_to_assume_role.path
-}
+# output "policy_path" {
+#   description = "path of policy attached to this role"
+#   value       = aws_iam_policy.iam_allowing_group_to_assume_role.path
+# }
 
-output "trust_policy" {
-  description = "trust role policy of this role"
-  value       = data.aws_iam_policy_document.iam_trusted.json
-}
+# output "trust_policy" {
+#   description = "trust role policy of this role"
+#   value       = data.aws_iam_policy_document.iam_trusted.json
+# }
 
 output "unique_id" {
   description = "unique id of the role"

--- a/variables.tf
+++ b/variables.tf
@@ -46,5 +46,5 @@ variable "identities" {
 variable "agency_assume_local_role_id" {
   description = "your role_id should be the agency_assume_local role_id, use aws iam list-roles to find out"
   type        = string
-  default     = "AROA9BAABCD5NSXYZE123"
+  default     = "AROA11ZZZZYYYYXXXX123"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,13 @@ variable "attach_policies" {
 }
 
 variable "identities" {
-  description = "list of users that can assume this role"
+  description = "list of users that can assume this role, i put map in case next time we need to add more stuff"
   type        = list(map(string))
-  default     = [{ "email" = "techpass_user@tech.gov.sg", "principal" = "AROA9BAABCD5NSXYZE123" },{ "email" = "techpass_developer@tech.gov.sg", "principal" = "AROA9BAABCD5NSXYZE455" }]
+  default     = [{ "email" = "techpass_user@tech.gov.sg" },{ "email" = "techpass_developer@tech.gov.sg" }]
+}
+
+variable "agency_assume_local_role_id" {
+  description = "your role_id should be the agency_assume_local role_id, use aws iam list-roles to find out"
+  type        = string
+  default     = "AROA9BAABCD5NSXYZE123"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "identities" {
 }
 
 variable "agency_assume_local_role_id" {
-  description = "your role_id should be the agency_assume_local role_id, use aws iam list-roles to find out"
+  description = "your role_id should be the agency_assume_local role_id, use aws iam list-roles to find out, looks like AROA11ZZZZYYYYXXXX123"
   type        = string
-  default     = "AROA11ZZZZYYYYXXXX123"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,34 +8,10 @@ variable "description" {
   type        = string
 }
 
-variable "trusted_root_accounts" {
-  description = "list of root accounts to assume this role, to be scoped by condition"
-  type        = list(string)
-  default     = []
-}
-
-variable "trusted_role_arns" {
-  description = "list of roles arn allowed to assume this role by condition"
-  type        = list(string)
-  default     = []
-}
-
-variable "external_id" {
-  description = "external id condition for assume role"
-  type        = string
-  default     = "default"
-}
-
 variable "max_session_duration" {
   description = "maximum duration in seconds for role, between 1 to 12 hours"
   type        = number
   default     = 3600
-}
-
-variable "group_names" {
-  description = "list of groups that can assume this role"
-  type        = list(string)
-  default     = []
 }
 
 variable "name" {
@@ -61,8 +37,8 @@ variable "attach_policies" {
   default     = {}
 }
 
-variable "enable_gcci_boundary" {
-  description = "toggle for gcci boundary to allow non-gcc accounts to create role"
-  type        = bool
-  default     = true
+variable "identities" {
+  description = "list of users that can assume this role"
+  type        = list(map(string))
+  default     = [{ "email" = "techpass_user@tech.gov.sg", "principal" = "AROA9BAABCD5NSXYZE123" },{ "email" = "techpass_developer@tech.gov.sg", "principal" = "AROA9BAABCD5NSXYZE455" }]
 }


### PR DESCRIPTION
use the AWS SSO for GCC2 login.

1. since that the trusted roles is always the agency_assume_local, there is no cross account assume role unlike in GCC1. so i remove it.

3. remove groups, because there are no more IAM users in gcc2 only SSO roles

4. enforce external-id to govtech email (maybe can be different? but i use external-id so that it can be easily identify in case of role assume inceptions)